### PR TITLE
fixed typo in README.rst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ schemagic.egg-info/
 schemagic/scratch.py
 does-it-work/
 schemagic/__pycache__/
+/schemagic/schemagic_stuff.py

--- a/README.rst
+++ b/README.rst
@@ -129,8 +129,8 @@ Schema checking is quite flexible, and all checks are done recursively.  Lets go
     ...        return data
     ...     return _validator
     >>> event = {
-    ...    "event_type": enum("PRODUCTION", "DEVELOPMENT")
-    ...    "event_name": str,
+    ...    "event_type": enum("PRODUCTION", "DEVELOPMENT"),
+    ...    "event_name": str
     ...}
     >>> dispatch_request = {
     ...    "events": [event],

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Schema checking is quite flexible, and all checks are done recursively.  Lets go
 .. code-block:: python
 
     >>> list_of_ints = [int]
-    >>> schemagic.validate_against_schema(string_to_int_map, [1, 2, 3, 4])
+    >>> schemagic.validate_against_schema(list_of_ints, [1, 2, 3, 4])
     [1, 2, 3, 4]
 
 **Strict Sequence**:

--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Schema checking is quite flexible, and all checks are done recursively.  Lets go
 .. code-block:: python
 
     >>> list_with_3_items_int_str_and_intstrmap = [int, str, {int: str}]
-    >>> schemagic.validate_against_schema(string_to_int_map, [1, "hello", {5: "friends", 12: "and", 90: "world"}])
+    >>> schemagic.validate_against_schema(list_with_3_items_int_str_and_intstrmap, [1, "hello", {5: "friends", 12: "and", 90: "world"}])
     [1, "hello", {5: "friends", 12: "and", 90: "world"}]
 
 **Validation Function**:

--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ Schemagic.validator Usage
 
     >>> __env__ = None
     >>> WHEN_IN_DEV_ENV = lambda: __env__ == "DEV"
-    >>> validate_in_dev = partial(schemagic.validator, validation_predicate=WHEN_IN_DEV)
+    >>> validate_in_dev = partial(schemagic.validator, validation_predicate=WHEN_IN_DEV_ENV)
     >>> list_of_ints_validator = validate_in_dev([int], "integer list")
     >>> __env__ = "DEV"
     >>> list_of_ints_validator([1, "not an int", 3])

--- a/schemagic/core.py
+++ b/schemagic/core.py
@@ -5,10 +5,13 @@ from schemagic.utils import merge_with, multiple_dispatch_fn
 
 WHEN_DEBUGGING = lambda: __debug__
 
+
 def validate_map_template(schema, value):
     key_schema, value_schema = schema.items()[0]
-    validate_key_val_pair = lambda key, val: (validate_against_schema(key_schema, key), validate_against_schema(value_schema, val))
+    validate_key_val_pair = lambda key, val: (
+    validate_against_schema(key_schema, key), validate_against_schema(value_schema, val))
     return dict(map(validate_key_val_pair, value.keys(), value.values()))
+
 
 def validate_keyed_mapping(schema, value):
     missing_keys = set(schema.keys()) - set(value.keys())
@@ -16,25 +19,34 @@ def validate_keyed_mapping(schema, value):
         raise ValueError("Missing keys {0} for value {1}".format(missing_keys, value))
     return merge_with(validate_against_schema, schema, value)
 
+
 def validate_sequence_template(schema, value):
-    return map(schema[0], value)
+    if hasattr(schema[0], '__call__'):
+        return map(schema[0], value)
+    return map(lambda _: apply(lambda _s, _v: validate_against_schema(_s, _v), _), zip(schema, value))
+
 
 def validate_strict_sequence(schema, value):
     if not len(schema) == len(value):
-        raise ValueError("sequence has a different number of elements than its schema prescribes.  value: {0}, schema: {1}".format(value, schema))
+        raise ValueError(
+            "sequence has a different number of elements than its schema prescribes.  value: {0}, schema: {1}".format(
+                value, schema))
     return map(lambda sub_schema, sub_value: validate_against_schema(sub_schema, sub_value), schema, value)
 
-is_map_template = lambda schema: isinstance(schema, collections.MutableMapping) and len(schema.items()) is 1 and not isinstance(schema.keys()[0], str)
+
+is_map_template = lambda schema: isinstance(schema, collections.MutableMapping) and len(
+    schema.items()) is 1 and not isinstance(schema.keys()[0], str)
 is_keyed_mapping = lambda schema: isinstance(schema, collections.MutableMapping) and not is_map_template(schema)
 is_sequence_template = lambda schema: isinstance(schema, collections.Sequence) and len(schema) is 1
 is_strict_sequence = lambda schema: isinstance(schema, collections.Sequence) and 1 < len(schema)
 
-validate_against_schema = multiple_dispatch_fn( "validate_against_schema", {
+validate_against_schema = multiple_dispatch_fn("validate_against_schema", {
     lambda schema, value: is_sequence_template(schema): validate_sequence_template,
     lambda schema, value: is_strict_sequence(schema): validate_strict_sequence,
     lambda schema, value: is_map_template(schema): validate_map_template,
     lambda schema, value: is_keyed_mapping(schema): validate_keyed_mapping},
-    default=lambda schema, value: schema(value))
+                                               default=lambda schema, value: schema(value))
+
 
 def validator(schema, subject_name_str, validation_predicate=None, coerce_data=False, data=None):
     if data is None:
@@ -52,4 +64,5 @@ def validator(schema, subject_name_str, validation_predicate=None, coerce_data=F
             "value": data,
             "schema": schema
         }
-        raise ValueError("Bad value provided for {subject}. - error: {error} schema: {schema} value: {value}".format(**message_details))
+        raise ValueError("Bad value provided for {subject}. - error: {error} schema: {schema} value: {value}".format(
+            **message_details))


### PR DESCRIPTION
Going through tutorial, noticed this part (might) not be syncing up, unless I'm missing something.  Made the edit that might be appropriate.  

Put in a bug fix for validate_sequence_template ... when I went through the tutorial it wasn't working as expecting with "enum".  Working now... please double check to make sure this is what was intended